### PR TITLE
feat: Default backend implementation

### DIFF
--- a/lib/logflare/backends.ex
+++ b/lib/logflare/backends.ex
@@ -73,6 +73,10 @@ defmodule Logflare.Backends do
 
         where(q, [b], b.metadata == ^normalized)
 
+      # filter by `default_ingest` flag
+      {:default_ingest, true}, q ->
+        where(q, [b], b.default_ingest? == true)
+
       _, q ->
         q
     end)

--- a/lib/logflare/backends/adaptor/bigquery_adaptor.ex
+++ b/lib/logflare/backends/adaptor/bigquery_adaptor.ex
@@ -228,6 +228,9 @@ defmodule Logflare.Backends.Adaptor.BigQueryAdaptor do
   def get_supported_languages, do: [:bq_sql]
 
   @impl Logflare.Backends.Adaptor
+  def supports_default_ingest?, do: true
+
+  @impl Logflare.Backends.Adaptor
   def cast_config(params) do
     {%{}, %{project_id: :string, dataset_id: :string}}
     |> Changeset.cast(params, [:project_id, :dataset_id])

--- a/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
+++ b/lib/logflare/backends/adaptor/clickhouse_adaptor.ex
@@ -115,6 +115,9 @@ defmodule Logflare.Backends.Adaptor.ClickhouseAdaptor do
   @impl Logflare.Backends.Adaptor
   def get_supported_languages, do: [:ch_sql]
 
+  @impl Logflare.Backends.Adaptor
+  def supports_default_ingest?, do: true
+
   @doc false
   @impl Logflare.Backends.Adaptor
   def cast_config(%{} = params) do

--- a/lib/logflare/backends/adaptor/postgres_adaptor.ex
+++ b/lib/logflare/backends/adaptor/postgres_adaptor.ex
@@ -147,6 +147,9 @@ defmodule Logflare.Backends.Adaptor.PostgresAdaptor do
   def get_supported_languages, do: [:pg_sql]
 
   @impl Logflare.Backends.Adaptor
+  def supports_default_ingest?, do: true
+
+  @impl Logflare.Backends.Adaptor
   def transform_query(query, :bq_sql, context) do
     if should_transform_bigquery_to_postgres?() do
       schema_prefix = Map.get(context, :schema_prefix)

--- a/lib/logflare/backends/adaptor/s3_adaptor.ex
+++ b/lib/logflare/backends/adaptor/s3_adaptor.ex
@@ -84,6 +84,9 @@ defmodule Logflare.Backends.Adaptor.S3Adaptor do
     config
   end
 
+  @impl Adaptor
+  def supports_default_ingest?, do: true
+
   @doc """
   Generates a via tuple based on a `Source` and `Backend` pair for this adaptor instance.
 

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -1,5 +1,6 @@
 defmodule Logflare.Source do
   @moduledoc false
+
   use TypedEctoSchema
 
   import Ecto.Changeset
@@ -32,11 +33,13 @@ defmodule Logflare.Source do
              :transform_copy_fields,
              :bigquery_clustering_fields
            ]}
+
   defp env_dataset_id_append,
     do: Application.get_env(:logflare, Logflare.Google)[:dataset_id_append]
 
   defmodule Metrics do
     @moduledoc false
+
     use TypedEctoSchema
 
     @derive {Jason.Encoder,
@@ -69,7 +72,9 @@ defmodule Logflare.Source do
 
   defmodule Notifications do
     @moduledoc false
+
     use Ecto.Schema
+
     @primary_key false
     @derive {Jason.Encoder,
              only: [
@@ -136,6 +141,7 @@ defmodule Logflare.Source do
     field(:retention_days, :integer, virtual: true)
     field(:transform_copy_fields, :string)
     field(:bigquery_clustering_fields, :string)
+    field(:default_ingest_enabled?, :boolean, source: :default_ingest_enabled, default: false)
     # Causes a shitstorm
     # field :bigquery_schema, Ecto.Term
 
@@ -189,7 +195,8 @@ defmodule Logflare.Source do
       :suggested_keys,
       :retention_days,
       :transform_copy_fields,
-      :disable_tailing
+      :disable_tailing,
+      :default_ingest_enabled?
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> put_single_tenant_postgres_changes()
@@ -218,7 +225,8 @@ defmodule Logflare.Source do
       :suggested_keys,
       :retention_days,
       :transform_copy_fields,
-      :disable_tailing
+      :disable_tailing,
+      :default_ingest_enabled?
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> put_single_tenant_postgres_changes()

--- a/lib/logflare/sources/source.ex
+++ b/lib/logflare/sources/source.ex
@@ -141,7 +141,12 @@ defmodule Logflare.Source do
     field(:retention_days, :integer, virtual: true)
     field(:transform_copy_fields, :string)
     field(:bigquery_clustering_fields, :string)
-    field(:default_ingest_enabled?, :boolean, source: :default_ingest_enabled, default: false)
+
+    field(:default_ingest_backend_enabled?, :boolean,
+      source: :default_ingest_backend_enabled,
+      default: false
+    )
+
     # Causes a shitstorm
     # field :bigquery_schema, Ecto.Term
 
@@ -196,7 +201,7 @@ defmodule Logflare.Source do
       :retention_days,
       :transform_copy_fields,
       :disable_tailing,
-      :default_ingest_enabled?
+      :default_ingest_backend_enabled?
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> put_single_tenant_postgres_changes()
@@ -226,7 +231,7 @@ defmodule Logflare.Source do
       :retention_days,
       :transform_copy_fields,
       :disable_tailing,
-      :default_ingest_enabled?
+      :default_ingest_backend_enabled?
     ])
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
     |> put_single_tenant_postgres_changes()

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -1,19 +1,52 @@
 defmodule LogflareWeb.Plugs.BufferLimiter do
   @moduledoc """
-  A plug that allows or denies API action based on the API request rate rules for user/source
+  A plug that rate limits API requests based on buffer capacity.
+
+  Returns 429 when the source's ingestion buffer is full, preventing
+  overload conditions. Supports default ingest backend filtering when
+  enabled on the source.
   """
+
   import Plug.Conn
+
   alias Logflare.Backends
+  alias Logflare.Source
 
-  def init(_opts), do: nil
+  @type opts :: any()
 
-  def call(%{assigns: %{source: source}} = conn, _opts \\ []) do
-    if Backends.cached_local_pending_buffer_full?(source) do
-      conn
-      |> send_resp(429, "Buffer full: Too many requests")
-      |> halt()
+  @doc false
+  @spec init(opts()) :: opts()
+  def init(opts), do: opts
+
+  @doc """
+  Checks buffer capacity and applies rate limiting based on source configuration.
+
+  - For sources with `default_ingest_enabled?: true`, only considers default ingest backends
+  - For standard sources, considers all backends when determining buffer fullness
+  """
+  @spec call(Plug.Conn.t(), opts()) :: Plug.Conn.t()
+  def call(conn, opts)
+
+  def call(%{assigns: %{source: %Source{default_ingest_enabled?: true} = source}} = conn, _opts) do
+    if Backends.cached_local_pending_buffer_full_default_ingest?(source) do
+      reject_request(conn)
     else
       conn
     end
+  end
+
+  def call(%{assigns: %{source: %Source{} = source}} = conn, _opts) do
+    if Backends.cached_local_pending_buffer_full?(source) do
+      reject_request(conn)
+    else
+      conn
+    end
+  end
+
+  @spec reject_request(Plug.Conn.t()) :: Plug.Conn.t()
+  defp reject_request(conn) do
+    conn
+    |> send_resp(429, "Buffer full: Too many requests")
+    |> halt()
   end
 end

--- a/lib/logflare_web/controllers/plugs/buffer_limiter.ex
+++ b/lib/logflare_web/controllers/plugs/buffer_limiter.ex
@@ -21,13 +21,16 @@ defmodule LogflareWeb.Plugs.BufferLimiter do
   @doc """
   Checks buffer capacity and applies rate limiting based on source configuration.
 
-  - For sources with `default_ingest_enabled?: true`, only considers default ingest backends
+  - For sources with `default_ingest_backend_enabled?: true`, only considers default ingest backends
   - For standard sources, considers all backends when determining buffer fullness
   """
   @spec call(Plug.Conn.t(), opts()) :: Plug.Conn.t()
   def call(conn, opts)
 
-  def call(%{assigns: %{source: %Source{default_ingest_enabled?: true} = source}} = conn, _opts) do
+  def call(
+        %{assigns: %{source: %Source{default_ingest_backend_enabled?: true} = source}} = conn,
+        _opts
+      ) do
     if Backends.cached_local_pending_buffer_full_default_ingest?(source) do
       reject_request(conn)
     else

--- a/priv/repo/migrations/20250804174212_add_default_ingest_flag_to_backends.exs
+++ b/priv/repo/migrations/20250804174212_add_default_ingest_flag_to_backends.exs
@@ -1,0 +1,14 @@
+defmodule Logflare.Repo.Migrations.AddDefaultIngestFlagToBackends do
+  use Ecto.Migration
+
+  def change do
+    alter table(:backends) do
+      add :default_ingest, :boolean, default: false
+    end
+
+    create index(:backends, [:source_id, :default_ingest],
+             where: "default_ingest = TRUE",
+             name: :idx_backends_default_ingest
+           )
+  end
+end

--- a/priv/repo/migrations/20250804174212_add_default_ingest_flag_to_backends.exs
+++ b/priv/repo/migrations/20250804174212_add_default_ingest_flag_to_backends.exs
@@ -6,7 +6,7 @@ defmodule Logflare.Repo.Migrations.AddDefaultIngestFlagToBackends do
       add :default_ingest, :boolean, default: false
     end
 
-    create index(:backends, [:source_id, :default_ingest],
+    create index(:backends, [:default_ingest],
              where: "default_ingest = TRUE",
              name: :idx_backends_default_ingest
            )

--- a/priv/repo/migrations/20250804175351_add_default_ingest_enabled_to_sources.exs
+++ b/priv/repo/migrations/20250804175351_add_default_ingest_enabled_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Logflare.Repo.Migrations.AddDefaultIngestEnabledToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :default_ingest_enabled, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20250804175351_add_default_ingest_enabled_to_sources.exs
+++ b/priv/repo/migrations/20250804175351_add_default_ingest_enabled_to_sources.exs
@@ -3,7 +3,7 @@ defmodule Logflare.Repo.Migrations.AddDefaultIngestEnabledToSources do
 
   def change do
     alter table(:sources) do
-      add :default_ingest_enabled, :boolean, default: false
+      add :default_ingest_backend_enabled, :boolean, default: false
     end
   end
 end

--- a/test/logflare/backends/backend_test.exs
+++ b/test/logflare/backends/backend_test.exs
@@ -1,0 +1,151 @@
+defmodule Logflare.Backends.BackendTest do
+  use Logflare.DataCase
+  alias Logflare.Backends.Backend
+
+  describe "changeset/2" do
+    setup do
+      user = insert(:user)
+      {:ok, user: user}
+    end
+
+    test "validates `default_ingest?` for BigQuery backend", %{user: user} do
+      attrs = %{
+        name: "Test BigQuery Backend",
+        type: :bigquery,
+        config: %{project_id: "test-project", dataset_id: "test-dataset"},
+        user_id: user.id,
+        default_ingest?: true
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :default_ingest?) == true
+    end
+
+    test "validates `default_ingest?` for ClickHouse backend", %{user: user} do
+      attrs = %{
+        name: "Test ClickHouse Backend",
+        type: :clickhouse,
+        config: %{url: "http://localhost:8123", database: "default", port: 8123},
+        user_id: user.id,
+        default_ingest?: true
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :default_ingest?) == true
+    end
+
+    test "validates `default_ingest?` for Postgres backend", %{user: user} do
+      attrs = %{
+        name: "Test Postgres Backend",
+        type: :postgres,
+        config: %{url: "postgres://localhost/test"},
+        user_id: user.id,
+        default_ingest?: true
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :default_ingest?) == true
+    end
+
+    test "validates `default_ingest?` for S3 backend", %{user: user} do
+      attrs = %{
+        name: "Test S3 Backend",
+        type: :s3,
+        config: %{
+          access_key_id: "test-key",
+          secret_access_key: "test-secret",
+          s3_bucket: "test-bucket",
+          storage_region: "us-east-1"
+        },
+        user_id: user.id,
+        default_ingest?: true
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :default_ingest?) == true
+    end
+
+    test "rejects `default_ingest?` for webhook backend", %{user: user} do
+      attrs = %{
+        name: "Test Webhook Backend",
+        type: :webhook,
+        config: %{url: "https://example.com/webhook"},
+        user_id: user.id,
+        default_ingest?: true
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      refute changeset.valid?
+
+      assert errors_on(changeset)[:default_ingest?] == [
+               "Backend type webhook does not support default ingest"
+             ]
+    end
+
+    test "rejects `default_ingest?` for datadog backend", %{user: user} do
+      attrs = %{
+        name: "Test Datadog Backend",
+        type: :datadog,
+        config: %{api_key: "test-api-key", url: "https://api.datadoghq.com"},
+        user_id: user.id,
+        default_ingest?: true
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      refute changeset.valid?
+
+      assert errors_on(changeset)[:default_ingest?] == [
+               "Backend type datadog does not support default ingest"
+             ]
+    end
+
+    test "allows `default_ingest?` false for any backend type", %{user: user} do
+      attrs = %{
+        name: "Test Webhook Backend",
+        type: :webhook,
+        config: %{url: "https://example.com/webhook"},
+        user_id: user.id,
+        default_ingest?: false
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      assert changeset.valid?
+      assert get_field(changeset, :default_ingest?) == false
+    end
+
+    test "defaults `default_ingest?` to false when not provided", %{user: user} do
+      attrs = %{
+        name: "Test BigQuery Backend",
+        type: :bigquery,
+        config: %{project_id: "test-project", dataset_id: "test-dataset"},
+        user_id: user.id
+      }
+
+      changeset = Backend.changeset(%Backend{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :default_ingest?) == nil
+      assert get_field(changeset, :default_ingest?) == false
+    end
+
+    test "validates `default_ingest?` only when changing to true", %{user: user} do
+      backend =
+        insert(:backend, type: :webhook, user: user, config: %{url: "https://example.com"})
+
+      attrs = %{name: "Updated Name"}
+      changeset = Backend.changeset(backend, attrs)
+      assert changeset.valid?
+
+      attrs = %{default_ingest?: true}
+      changeset = Backend.changeset(backend, attrs)
+      refute changeset.valid?
+
+      assert errors_on(changeset)[:default_ingest?] == [
+               "Backend type webhook does not support default ingest"
+             ]
+    end
+  end
+end

--- a/test/logflare/backends_test.exs
+++ b/test/logflare/backends_test.exs
@@ -82,7 +82,7 @@ defmodule Logflare.BackendsTest do
           default_ingest?: true
         )
 
-      results = Backends.list_backends(default_ingest: true, user_id: user.id)
+      results = Backends.list_backends(default_ingest?: true, user_id: user.id)
       assert length(results) == 2
 
       result_ids = Enum.map(results, & &1.id) |> Enum.sort()
@@ -130,7 +130,7 @@ defmodule Logflare.BackendsTest do
 
       assert {:ok, _} = Backends.update_source_backends(source, [backend1, backend2, backend3])
 
-      results = Backends.list_backends(source_id: source.id, default_ingest: true)
+      results = Backends.list_backends(source_id: source.id, default_ingest?: true)
       assert length(results) == 2
 
       result_ids = Enum.map(results, & &1.id) |> Enum.sort()

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -122,7 +122,7 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
   describe "default ingest feature" do
     setup do
       user = insert(:user)
-      source = insert(:source, user: user, default_ingest_enabled?: true)
+      source = insert(:source, user: user, default_ingest_backend_enabled?: true)
 
       backend1 =
         insert(:backend,
@@ -205,10 +205,10 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
       assert conn.status == 429
     end
 
-    test "falls back to regular buffer check when default_ingest_enabled? is false", %{
+    test "falls back to regular buffer check when default_ingest_backend_enabled? is false", %{
       conn: conn
     } do
-      source = insert(:source, user: insert(:user), default_ingest_enabled?: false)
+      source = insert(:source, user: insert(:user), default_ingest_backend_enabled?: false)
 
       table_key = {source.id, nil, self()}
       IngestEventQueue.upsert_tid(table_key)

--- a/test/logflare_web/plugs/buffer_limiter_test.exs
+++ b/test/logflare_web/plugs/buffer_limiter_test.exs
@@ -118,4 +118,115 @@ defmodule LogflareWeb.Plugs.BufferLimiterTest do
 
     assert conn.halted == false
   end
+
+  describe "default ingest feature" do
+    setup do
+      user = insert(:user)
+      source = insert(:source, user: user, default_ingest_enabled?: true)
+
+      backend1 =
+        insert(:backend,
+          user: user,
+          type: :bigquery,
+          config: %{project_id: "test", dataset_id: "test"},
+          default_ingest?: true
+        )
+
+      backend2 =
+        insert(:backend,
+          user: user,
+          type: :webhook,
+          config: %{url: "http://test.com"},
+          default_ingest?: false
+        )
+
+      {:ok, _} = Backends.update_source_backends(source, [backend1, backend2])
+
+      conn = build_conn(:post, "/api/logs", %{"message" => "some text"})
+
+      {:ok, conn: conn, source: source, backend1: backend1, backend2: backend2}
+    end
+
+    test "returns 429 only when default ingest backend is full", %{
+      conn: conn,
+      source: source,
+      backend1: backend1,
+      backend2: backend2
+    } do
+      table_key_webhook = {source.id, backend2.id, self()}
+      IngestEventQueue.upsert_tid(table_key_webhook)
+
+      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
+        le = build(:log_event)
+        IngestEventQueue.add_to_table(table_key_webhook, [le])
+      end
+
+      table_key_bigquery = {source.id, backend1.id, self()}
+      IngestEventQueue.upsert_tid(table_key_bigquery)
+
+      for _ <- 1..100 do
+        le = build(:log_event)
+        IngestEventQueue.add_to_table(table_key_bigquery, [le])
+      end
+
+      Backends.cache_local_buffer_lens(source.id, backend1.id)
+      Backends.cache_local_buffer_lens(source.id, backend2.id)
+
+      conn =
+        conn
+        |> assign(:source, source)
+        |> BufferLimiter.call(%{})
+
+      assert conn.halted == false
+    end
+
+    test "returns 429 when default ingest backend is full", %{
+      conn: conn,
+      source: source,
+      backend1: backend1
+    } do
+      table_key = {source.id, backend1.id, self()}
+      IngestEventQueue.upsert_tid(table_key)
+
+      # Fill up the default ingest backend
+      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
+        le = build(:log_event)
+        IngestEventQueue.add_to_table(table_key, [le])
+      end
+
+      Backends.cache_local_buffer_lens(source.id, backend1.id)
+
+      conn =
+        conn
+        |> assign(:source, source)
+        |> BufferLimiter.call(%{})
+
+      assert conn.halted == true
+      assert conn.status == 429
+    end
+
+    test "falls back to regular buffer check when default_ingest_enabled? is false", %{
+      conn: conn
+    } do
+      source = insert(:source, user: insert(:user), default_ingest_enabled?: false)
+
+      table_key = {source.id, nil, self()}
+      IngestEventQueue.upsert_tid(table_key)
+
+      for _ <- 1..(Backends.max_buffer_queue_len() + 500) do
+        le = build(:log_event)
+        IngestEventQueue.add_to_table(table_key, [le])
+      end
+
+      Backends.cache_local_buffer_lens(source.id, nil)
+
+      conn =
+        conn
+        |> assign(:source, source)
+        |> BufferLimiter.call(%{})
+
+      assert conn.halted == true
+      assert conn.status == 429
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -103,6 +103,7 @@ defmodule Logflare.Factory do
       user_id: attrs[:user_id],
       user: attrs[:user],
       metadata: attrs[:metadata] || nil,
+      default_ingest?: attrs[:default_ingest?] || false,
       updated_at: attrs[:updated_at],
       inserted_at: attrs[:inserted_at],
       alert_queries: attrs[:alert_queries] || []


### PR DESCRIPTION
Implements a simple default backend feature using a new boolean attribute.

Requirements:

> - user can set an ingesting backend (BQ, CH, PG, S3, etc) as a 'default ingest' backend using boolean flag on `backends` table
> - default ingest backend is on top of the system-wide backend (bq for the service) that the application starts up with
> - default ingesting backend needs client back-pressure (429) as well
> - default ingesting backend needs to be enabled/disabled at a source-level for testing on prod

Currently lacks any UX.

_Waiting for upstream [PR#2585](https://github.com/Logflare/logflare/pull/2585) to merge and then will rebase against main..._